### PR TITLE
Fix SQL error on install

### DIFF
--- a/Upload/inc/plugins/myprofile/myprofileutils.class.php
+++ b/Upload/inc/plugins/myprofile/myprofileutils.class.php
@@ -54,8 +54,8 @@ abstract class MyProfileUtils {
      */
     public static function insert_settinggroups($settinggroups) {
         global $db;
-        $query = $db->simple_select("settinggroups", "COUNT(*) as `rows`");
-        $rows = $db->fetch_field($query, "rows");
+        $query = $db->simple_select("settinggroups", "COUNT(*) as `cnt`");
+        $rows = $db->fetch_field($query, "cnt");
         $settinggroups = array(
             "name" => $settinggroups["name"],
             "title" => $db->escape_string($settinggroups["title"]),


### PR DESCRIPTION
Original uses "rows" as an alias, which is a reserved keyword and leads to an SQL error on install, at least on the currently latest version of mariaDB. This should fix it.