### PR TITLE
Typecast approved field to integer

### DIFF
--- a/Upload/inc/plugins/myprofile/myprofilecomments.class.php
+++ b/Upload/inc/plugins/myprofile/myprofilecomments.class.php
@@ -1636,7 +1636,7 @@ $(document).ready(function() {
             "userid" => (int) $user["uid"],
             "cuid" => (int) $mybb->user["uid"],
             "message" => $db->escape_string($message),
-            "approved" => $approved,
+            "approved" => (int) $approved,
             "isprivate" => $isprivate,
             "time" => TIME_NOW
         );
@@ -1667,7 +1667,7 @@ $(document).ready(function() {
 
         $update_array = array(
             "message" => $db->escape_string($message),
-            "approved" => $approved,
+            "approved" => (int) $approved,
             "isprivate" => $isprivate
         );
         $cid = $db->update_query("myprofilecomments", $update_array, "cid='{$cid}'", "1");


### PR DESCRIPTION
This pull request fixes an issue where an empty string is sent to the database in some cases, resulting in the following SQL error:

```
"SQL Error: 1366 – Incorrect integer value: '' for column 'approved' at row 1"
```

It fixes the issue by typecasting the value to an integer before sending it to the database so that the empty string will become 0.