### PR TITLE
Fix incorrect integer value error

### DIFF
--- a/Upload/inc/plugins/myprofile/myprofilecomments.class.php
+++ b/Upload/inc/plugins/myprofile/myprofilecomments.class.php
@@ -2040,10 +2040,10 @@ $(document).ready(function() {
     public function admin_user_groups_edit_commit() {
         global $updated_group, $mybb;
 
-        $updated_group['canmanagecomments'] = $mybb->input['canmanagecomments'];
-        $updated_group['cansendcomments'] = $mybb->input['cansendcomments'];
-        $updated_group['caneditowncomments'] = $mybb->input['caneditowncomments'];
-        $updated_group['candeleteowncomments'] = $mybb->input['candeleteowncomments'];
+        $updated_group['canmanagecomments'] = (int) $mybb->input['canmanagecomments'];
+        $updated_group['cansendcomments'] = (int) $mybb->input['cansendcomments'];
+        $updated_group['caneditowncomments'] = (int) $mybb->input['caneditowncomments'];
+        $updated_group['candeleteowncomments'] = (int) $mybb->input['candeleteowncomments'];
         $updated_group['commentsperday'] = (int) $mybb->input['commentsperday'];
     }
 


### PR DESCRIPTION
When unchecked, the checkboxes processed by lines 2043-2046 can cause a SQL error due to null being passed as an integer value. This fix typecasts those lines to an integer so unchecked will be 0 and checked will be 1.

This is the same type of fix as was in #87.